### PR TITLE
fixed sharded weight loading

### DIFF
--- a/opendit/utils/download.py
+++ b/opendit/utils/download.py
@@ -8,7 +8,7 @@
 Functions for downloading pre-trained DiT models
 """
 import os
-
+import json
 import torch
 from torchvision.datasets.utils import download_url
 
@@ -41,7 +41,7 @@ def find_model(model_name):
                     bin_to_weight_mapping[v] = [k]
             
             # make state dict
-            state_dict = dict
+            state_dict = dict()
             for bin_name, weight_list in bin_to_weight_mapping.items():
                 bin_path = os.path.join(model_name, bin_name)
                 bin_state_dict = torch.load(bin_path, map_location=lambda storage, loc: storage)


### PR DESCRIPTION
I encountered this error `AssertionError: Could not find DiT checkpoint at ./outputs/000-vDiT-XL-222/epoch999-global_step2000/model/` during smapling. I notice that `shard=True` is enabled when saving the model weights, we should provide a loading method for sharded weights.